### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/generic/processor.rb
+++ b/lib/metanorma/generic/processor.rb
@@ -40,10 +40,6 @@ module Metanorma
         "Metanorma::Generic #{Metanorma::Generic::VERSION}"
       end
 
-      def input_to_isodoc(file, filename)
-        Metanorma::Input::Asciidoc.new.process(file, filename, @asciidoctor_backend)
-      end
-
       def extract_options(file)
         head = file.sub(/\n\n.*$/m, "\n")
         /\n:htmlstylesheet: (?<htmlstylesheet>[^\n]+)\n/ =~ head


### PR DESCRIPTION
move the Metanorma::Generic::Processor#input_to_isodoc method to Metanorma::Processor
https://github.com/metanorma/metanorma-cli/issues/134